### PR TITLE
Add Flutter desktop scheduler skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+# Flutter build outputs
+build/
+.dart_tool/
+.packages
+.pub/
+
+# Logs
+*.log

--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
-# SoundScheduler
+# Sound Scheduler
+
+This project contains a Flutter-based desktop application for scheduling and playing sounds with calendar support. The app provides:
+
+- Calendar view of scheduled songs
+- Template management for quick day setup
+- Remote control over HTTP (volume and template adjustments)
+- Simple in-app log of played sounds
+
+The code is a basic skeleton intended for further development. It requires the Flutter SDK with Windows desktop support enabled to run.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,0 +1,154 @@
+import 'dart:io';
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:table_calendar/table_calendar.dart';
+
+import 'models/template.dart';
+import 'models/schedule.dart';
+import 'providers/scheduler_provider.dart';
+import 'remote_control.dart';
+
+void main() {
+  runApp(const SoundSchedulerApp());
+  // Start remote control server
+  RemoteControl().start();
+}
+
+class SoundSchedulerApp extends StatelessWidget {
+  const SoundSchedulerApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return ChangeNotifierProvider(
+      create: (_) => SchedulerProvider(),
+      child: MaterialApp(
+        title: 'Sound Scheduler',
+        theme: ThemeData(
+          colorScheme: ColorScheme.fromSeed(seedColor: Colors.blue),
+          useMaterial3: true,
+        ),
+        home: const HomePage(),
+      ),
+    );
+  }
+}
+
+class HomePage extends StatefulWidget {
+  const HomePage({super.key});
+
+  @override
+  State<HomePage> createState() => _HomePageState();
+}
+
+class _HomePageState extends State<HomePage> {
+  CalendarFormat _calendarFormat = CalendarFormat.month;
+  DateTime _focusedDay = DateTime.now();
+
+  @override
+  Widget build(BuildContext context) {
+    final provider = Provider.of<SchedulerProvider>(context);
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Sound Scheduler'),
+      ),
+      body: Row(
+        children: [
+          NavigationRail(
+            destinations: const [
+              NavigationRailDestination(
+                  icon: Icon(Icons.calendar_today), label: Text('Schedule')),
+              NavigationRailDestination(
+                  icon: Icon(Icons.library_music), label: Text('Templates')),
+              NavigationRailDestination(
+                  icon: Icon(Icons.list), label: Text('Logs')),
+            ],
+            selectedIndex: provider.selectedIndex,
+            onDestinationSelected: provider.setSelectedIndex,
+          ),
+          const VerticalDivider(width: 1),
+          Expanded(
+            child: IndexedStack(
+              index: provider.selectedIndex,
+              children: const [
+                ScheduleView(),
+                TemplateView(),
+                LogView(),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class ScheduleView extends StatelessWidget {
+  const ScheduleView({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final provider = Provider.of<SchedulerProvider>(context);
+    return Column(
+      children: [
+        TableCalendar(
+          focusedDay: provider.focusedDay,
+          firstDay: DateTime(2020),
+          lastDay: DateTime(2100),
+          calendarFormat: provider.calendarFormat,
+          selectedDayPredicate: (day) =>
+              isSameDay(provider.selectedDay, day),
+          onDaySelected: (selectedDay, focusedDay) {
+            provider.onDaySelected(selectedDay, focusedDay);
+          },
+          onFormatChanged: provider.onFormatChanged,
+        ),
+        Expanded(
+          child: ListView.builder(
+            itemCount: provider.getEventsForDay(provider.selectedDay).length,
+            itemBuilder: (context, index) {
+              final event =
+                  provider.getEventsForDay(provider.selectedDay)[index];
+              return ListTile(
+                title: Text(event.song),
+                subtitle: Text(event.time.format(context)),
+              );
+            },
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class TemplateView extends StatelessWidget {
+  const TemplateView({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final provider = Provider.of<SchedulerProvider>(context);
+    return ListView(
+      children: [
+        for (final template in provider.templates)
+          ListTile(
+            title: Text(template.name),
+            onTap: () => provider.setDayTemplate(
+                provider.selectedDay, template),
+          ),
+      ],
+    );
+  }
+}
+
+class LogView extends StatelessWidget {
+  const LogView({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final provider = Provider.of<SchedulerProvider>(context);
+    return ListView(
+      children: provider.logs
+          .map((log) => ListTile(title: Text(log)))
+          .toList(),
+    );
+  }
+}

--- a/lib/models/schedule.dart
+++ b/lib/models/schedule.dart
@@ -1,0 +1,16 @@
+import 'package:flutter/material.dart';
+import 'template.dart';
+
+class ScheduleEvent {
+  final String song;
+  final TimeOfDay time;
+  ScheduleEvent(this.song, this.time);
+}
+
+class DaySchedule {
+  final DateTime day;
+  Template? template;
+  final List<ScheduleEvent> events = [];
+
+  DaySchedule(this.day, {this.template});
+}

--- a/lib/models/template.dart
+++ b/lib/models/template.dart
@@ -1,0 +1,11 @@
+class SongEntry {
+  final String song;
+  final Duration offset;
+  SongEntry(this.song, this.offset);
+}
+
+class Template {
+  final String name;
+  final List<SongEntry> entries;
+  Template(this.name, this.entries);
+}

--- a/lib/providers/scheduler_provider.dart
+++ b/lib/providers/scheduler_provider.dart
@@ -1,0 +1,65 @@
+import 'package:flutter/material.dart';
+import '../models/template.dart';
+import '../models/schedule.dart';
+import '../utils/logger.dart';
+
+class SchedulerProvider with ChangeNotifier {
+  final Map<DateTime, DaySchedule> _schedules = {};
+  final List<Template> templates = [
+    Template('Default', [
+      SongEntry('song1.mp3', const Duration(minutes: 0)),
+      SongEntry('song2.mp3', const Duration(minutes: 30)),
+    ]),
+  ];
+
+  final Logger _logger = Logger();
+
+  int selectedIndex = 0;
+  DateTime focusedDay = DateTime.now();
+  DateTime selectedDay = DateTime.now();
+  CalendarFormat calendarFormat = CalendarFormat.month;
+
+  List<String> get logs => _logger.logs;
+
+  void log(String msg) {
+    _logger.log(msg);
+    notifyListeners();
+  }
+
+  void setSelectedIndex(int index) {
+    selectedIndex = index;
+    notifyListeners();
+  }
+
+  void onDaySelected(DateTime selected, DateTime focused) {
+    selectedDay = selected;
+    focusedDay = focused;
+    notifyListeners();
+  }
+
+  void onFormatChanged(CalendarFormat format) {
+    calendarFormat = format;
+    notifyListeners();
+  }
+
+  void setDayTemplate(DateTime day, Template template) {
+    final date = DateTime(day.year, day.month, day.day);
+    final schedule = _schedules.putIfAbsent(date, () => DaySchedule(date));
+    schedule.template = template;
+    _logger.log('Template "${template.name}" applied to $date');
+    notifyListeners();
+  }
+
+  List<ScheduleEvent> getEventsForDay(DateTime day) {
+    final date = DateTime(day.year, day.month, day.day);
+    return _schedules[date]?.events ?? [];
+  }
+
+  void addEvent(DateTime day, ScheduleEvent event) {
+    final date = DateTime(day.year, day.month, day.day);
+    final schedule = _schedules.putIfAbsent(date, () => DaySchedule(date));
+    schedule.events.add(event);
+    _logger.log('Scheduled ${event.song} on $date at ${event.time.hour}:${event.time.minute.toString().padLeft(2,'0')}');
+    notifyListeners();
+  }
+}

--- a/lib/remote_control.dart
+++ b/lib/remote_control.dart
@@ -1,0 +1,29 @@
+import 'dart:convert';
+import 'dart:io';
+import 'package:provider/provider.dart';
+import 'package:flutter/material.dart';
+import 'providers/scheduler_provider.dart';
+
+class RemoteControl {
+  HttpServer? _server;
+
+  Future<void> start({int port = 4040}) async {
+    _server = await HttpServer.bind(InternetAddress.loopbackIPv4, port);
+    _server!.listen(_handleRequest);
+  }
+
+  void _handleRequest(HttpRequest request) async {
+    final provider = Provider.of<SchedulerProvider>(navigatorKey.currentContext!, listen: false);
+    if (request.method == 'POST' && request.uri.path == '/volume') {
+      final body = await utf8.decoder.bind(request).join();
+      provider.log('Volume change: $body');
+      request.response.write('OK');
+    } else {
+      request.response.statusCode = HttpStatus.notFound;
+    }
+    await request.response.close();
+  }
+}
+
+
+final GlobalKey<NavigatorState> navigatorKey = GlobalKey<NavigatorState>();

--- a/lib/utils/logger.dart
+++ b/lib/utils/logger.dart
@@ -1,0 +1,8 @@
+class Logger {
+  final List<String> logs = [];
+
+  void log(String message) {
+    final timestamp = DateTime.now().toIso8601String();
+    logs.add('[$timestamp] $message');
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,0 +1,18 @@
+name: sound_scheduler
+description: A desktop sound scheduler with calendar view and remote control.
+version: 0.1.0
+
+environment:
+  sdk: '>=3.0.0 <4.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+  cupertino_icons: ^1.0.6
+  table_calendar: ^3.0.9
+  provider: ^6.1.2
+
+flutter:
+  uses-material-design: true
+  assets:
+    - data/


### PR DESCRIPTION
## Summary
- set up project layout for a Flutter desktop sound scheduler
- provide scheduling, templates and logging models
- add basic provider and remote control HTTP server
- include placeholder main UI with calendar and tabs
- document project and add `.gitignore`

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68545c89befc83258326227e3a9b89b4